### PR TITLE
Allowed commands to be formatted with params through the use command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,9 @@ Detailed usage has been documented for each command and can be viewed at the fol
 
 * [Examples](examples/catacomb) for the `catacomb` entry point
 * [Examples](examples/tomb) for the `tomb` entry point
+
+### Contributing
+
+This project is still in its infancy, so feel free to contribute by reporting issues or suggesting some new features. Pull requests are definitely welcomed!
+
+Please be sure that any contributions follow [PEP8](https://www.python.org/dev/peps/pep-0008/) standards.

--- a/catacomb/commands/tomb/use.py
+++ b/catacomb/commands/tomb/use.py
@@ -31,6 +31,7 @@ def use(ctx, alias, params):
         # The command alias doesn't exist.
         formatter.print_warning(constants.WARN_CMD_NOT_FOUND.format(alias))
 
+
 def format_cmd(cmd, params):
     """Formats a command with user provided parameters, similar to the Python
     `format()` method.
@@ -50,10 +51,27 @@ def format_cmd(cmd, params):
         return cmd.format(*params)
     except IndexError:
         # Not all the placeholders are provided with a value.
-        formatter.exit(constants.WARN_FMT_NUM_PARAMS)
+        formatter.exit(constants.WARN_FMT_NUM_PARAMS.format(
+            len(params), num_parameters(cmd)))
     except KeyError:
         # Placeholders aren't following the correct syntax.
         formatter.exit(constants.WARN_FMT_PLACEHOLDER_SYNTAX)
-    except:
+    except ValueError:
+        # TODO: {} {0} {} {1}
+        pass
+    except Exception:
         # This shouldn't be reachable, but just in case, we'll report it.
         formatter.exit(errors.INVALID_FORMAT_USE_CMD.format(cmd))
+
+
+def num_parameters(cmd):
+    """Retrieves the number of placeholders in a command.
+
+    Arguments:
+        cmd (str): The command.
+
+    Returns:
+        An `int` representing the number of placeholders in the command.
+    """
+    # TODO
+    return 0

--- a/catacomb/commands/tomb/use.py
+++ b/catacomb/commands/tomb/use.py
@@ -24,7 +24,7 @@ def use(ctx, alias, params):
         if params:
             # Substitute any placeholders in the command with the provided
             # parameters.
-            cmd = format_cmd(cmd, params)
+            cmd = format_cmd(alias, cmd, params)
         # Execute the command.
         os.system(cmd)
     else:
@@ -32,7 +32,7 @@ def use(ctx, alias, params):
         formatter.print_warning(constants.WARN_CMD_NOT_FOUND.format(alias))
 
 
-def format_cmd(cmd, params):
+def format_cmd(alias, cmd, params):
     """Formats a command with user provided parameters, similar to the Python
     `format()` method.
 
@@ -52,26 +52,13 @@ def format_cmd(cmd, params):
     except IndexError:
         # Not all the placeholders are provided with a value.
         formatter.exit(constants.WARN_FMT_NUM_PARAMS.format(
-            len(params), num_parameters(cmd)))
+            alias, len(params)))
     except KeyError:
         # Placeholders aren't following the correct syntax.
         formatter.exit(constants.WARN_FMT_PLACEHOLDER_SYNTAX)
     except ValueError:
-        # TODO: {} {0} {} {1}
-        pass
+        # Inconsistent use of placeholders in a command.
+        formatter.exit(constants.WARN_FMT_PLACEHOLDER_SYNTAX2)
     except Exception:
         # This shouldn't be reachable, but just in case, we'll report it.
         formatter.exit(errors.INVALID_FORMAT_USE_CMD.format(cmd))
-
-
-def num_parameters(cmd):
-    """Retrieves the number of placeholders in a command.
-
-    Arguments:
-        cmd (str): The command.
-
-    Returns:
-        An `int` representing the number of placeholders in the command.
-    """
-    # TODO
-    return 0

--- a/catacomb/commands/tomb/use.py
+++ b/catacomb/commands/tomb/use.py
@@ -1,7 +1,7 @@
 import click
 import os
 
-from catacomb.common import constants
+from catacomb.common import constants, errors
 from catacomb.utils import formatter, tomb_handler
 
 
@@ -9,18 +9,51 @@ from catacomb.utils import formatter, tomb_handler
     constants.CMD_USE_NAME, help=constants.CMD_USE_DESC,
     short_help=constants.CMD_USE_DESC)
 @click.argument("alias", nargs=1)
+@click.argument("params", nargs=-1)
 @click.pass_context
-def use(ctx, alias):
+def use(ctx, alias, params):
     """Retrieves a command from the tomb and executes it.
 
     Arguments:
         alias (str): The alias of the command to execute.
+        params (tuple): Optional parameters to be formatted into the command.
     """
     cmd = tomb_handler.get_command(ctx, alias)
 
     if cmd:
-        # Execute the retrieved command.
+        if params:
+            # Substitute any placeholders in the command with the provided
+            # parameters.
+            cmd = format_cmd(cmd, params)
+        # Execute the command.
         os.system(cmd)
     else:
         # The command alias doesn't exist.
         formatter.print_warning(constants.WARN_CMD_NOT_FOUND.format(alias))
+
+def format_cmd(cmd, params):
+    """Formats a command with user provided parameters, similar to the Python
+    `format()` method.
+
+    Arguments:
+        cmd (str): The command.
+        params (tuple): Parameters to be formatted into the command.
+
+    Returns:
+        A `string` representing the newly formatted command.
+    """
+    try:
+        # In the case of more parameters vs placeholders, we will exhaust what
+        # we can (in order) and run the command anyway. If nothing can be
+        # substituted, the formatting will be ignored and the command will be
+        # run as is.
+        return cmd.format(*params)
+    except IndexError:
+        # Not all the placeholders are provided with a value.
+        formatter.exit(constants.WARN_FMT_NUM_PARAMS)
+    except KeyError:
+        # Placeholders aren't following the correct syntax.
+        formatter.exit(constants.WARN_FMT_PLACEHOLDER_SYNTAX)
+    except:
+        # This shouldn't be reachable, but just in case, we'll report it.
+        formatter.exit(errors.INVALID_FORMAT_USE_CMD.format(cmd))

--- a/catacomb/common/constants.py
+++ b/catacomb/common/constants.py
@@ -82,3 +82,9 @@ WARN_EMPTY_TOMB = "Nothing but crumbled bones and dust..."
 WARN_TOMB_EXISTS = "The tomb with alias '{0}' already exists."
 WARN_TOMB_NOT_FOUND = (
     "The alias '{0}' doesn't correspond to any of the tombs in the catacomb.")
+WARN_FMT_NUM_PARAMS = (
+    "{0} parameters were provided, but we needed at least {1}.")
+WARN_FMT_PLACEHOLDER_SYNTAX = (
+    "The placeholders in this command don't adhere to the correct syntax. "
+    "Please either use empty curly brackets '{}' or specify the index with "
+    "a number, e.g. '{0} {1} {2}'.")

--- a/catacomb/common/constants.py
+++ b/catacomb/common/constants.py
@@ -83,8 +83,11 @@ WARN_TOMB_EXISTS = "The tomb with alias '{0}' already exists."
 WARN_TOMB_NOT_FOUND = (
     "The alias '{0}' doesn't correspond to any of the tombs in the catacomb.")
 WARN_FMT_NUM_PARAMS = (
-    "{0} parameters were provided, but we needed at least {1}.")
+    "Not enough parameters to use '{0}', {1} were provided.")
 WARN_FMT_PLACEHOLDER_SYNTAX = (
     "The placeholders in this command don't adhere to the correct syntax. "
     "Please either use empty curly brackets '{}' or specify the index with "
     "a number, e.g. '{0} {1} {2}'.")
+WARN_FMT_PLACEHOLDER_SYNTAX2 = (
+    "There are both types of placeholders in this command, '{}' and "
+    "'{[0-9]+}'. Commands should use only one type.")

--- a/catacomb/common/errors.py
+++ b/catacomb/common/errors.py
@@ -1,5 +1,9 @@
 # General application errors.
 INVALID_COLOR = "Error 100: The desired color is not available, '{0}'."
+INVALID_FORMAT_USE_CMD = (
+    "Error 101: A formatting error occured and we're not sure why. Please "
+    "report this at https://github.com/mitchjeitani/catacomb.\nCommand used "
+    "was: {0}.")
 
 # Catacomb handling errors.
 TOMB_OPEN_UNKNOWN = (

--- a/examples/tomb/use.md
+++ b/examples/tomb/use.md
@@ -1,7 +1,7 @@
 ### Usage
 
 ```
-Usage: tomb use [OPTIONS] ALIAS
+Usage: tomb use [OPTIONS] ALIAS [PARAMS]...
 
   Grabs a command from the tomb and executes it.
 
@@ -13,4 +13,11 @@ Options:
 
 ```
 $ tomb use pipify
+```
+
+If the command contains placeholders of the form `{}` or `{[0-9]+}`, for example: `echo My name is {0}. I'm from {1}.`, you can include parameters to `tomb use` for substitution.
+
+```
+$ tomb use echo_name Mitch Australia
+My name is Mitch. I'm from Australia.
 ```


### PR DESCRIPTION
You can now save commands with placeholders and then format them later using the `tomb use` command. For example:

```
>  tomb add test
Command: echo Hi, my {0} is {1}
Description: Echo with placeholders.
> tomb use test name Mitch
Hi, my name is Mitch
```