### PR TITLE
Closes #6: Added the ability to edit commands with a text editor.

### DIFF
--- a/catacomb/commands/tomb/add.py
+++ b/catacomb/commands/tomb/add.py
@@ -1,7 +1,7 @@
 import click
 
 from catacomb.common import constants
-from catacomb.utils import formatter, tomb_handler
+from catacomb.utils import formatter, helpers, tomb_handler
 
 
 @click.command(
@@ -27,7 +27,7 @@ def add(ctx, alias, command):
         update = click.prompt(constants.CMD_ADD_UPDATE_PROMPT.format(alias))
         if update.lower() != "y":
             # Abort the action.
-            formatter.exit(constants.WARN_ACTION_ABORTED)
+            helpers.exit(constants.WARN_ACTION_ABORTED)
 
     if not command:
         # If the `command` hasn't yet been specified we'll need to prompt the

--- a/catacomb/commands/tomb/add.py
+++ b/catacomb/commands/tomb/add.py
@@ -20,15 +20,14 @@ def add(ctx, alias, command):
         alias (str): The alias of the command being added to the tomb.
         command (str): The command to add to the tomb.
     """
-    if tomb_handler.get_command(ctx, alias):
+    if tomb_handler.is_existing_command(ctx, alias):
         # If the `alias` specified is already used for a command in the tomb,
         # prompt the user to determine if they want to overwrite the old
         # command.
         update = click.prompt(constants.CMD_ADD_UPDATE_PROMPT.format(alias))
         if update.lower() != "y":
             # Abort the action.
-            formatter.print_warning(constants.WARN_ACTION_ABORTED)
-            return
+            formatter.exit(constants.WARN_ACTION_ABORTED)
 
     if not command:
         # If the `command` hasn't yet been specified we'll need to prompt the

--- a/catacomb/commands/tomb/edit.py
+++ b/catacomb/commands/tomb/edit.py
@@ -1,0 +1,126 @@
+import os
+import tempfile
+import click
+
+from catacomb import settings
+from catacomb.common import constants
+from catacomb.utils import formatter, tomb_handler
+
+from subprocess import call
+
+
+@click.command(
+    constants.CMD_EDIT_NAME, help=constants.CMD_EDIT_DESC,
+    short_help=constants.CMD_EDIT_DESC)
+@click.argument("alias", nargs=1)
+@click.pass_context
+def edit(ctx, alias):
+    """Edits a command if it's present in the active tomb.
+
+    Opens an editor for the user with the details for the specified command,
+    allowing edits to the alias, command and description.
+
+    Arguments:
+        alias (str): The alias of the command to edit.
+    """
+    if not tomb_handler.is_existing_command(ctx, alias):
+        formatter.exit(constants.WARN_CMD_NOT_FOUND.format(alias))
+
+    editor = os.environ.get("EDITOR", settings.DEFAULT_EDITOR)
+    cmd_info = tomb_handler.get_command(ctx, alias, True)
+
+    # Creates a temporary file with the current command information, allowing
+    # edits.
+    with tempfile.NamedTemporaryFile("r+", suffix=".tmp") as temp_file:
+        # Append the initial message to the file.
+        temp_file.write(constants.CMD_EDIT_INIT_MSG.format(
+            alias, cmd_info[0], cmd_info[1]))
+        temp_file.flush()
+
+        # Open the file within an editor.
+        call([editor, temp_file.name])
+
+        # Read changes to the file after the user is done with it.
+        temp_file.seek(0)
+        edits = read_edits(temp_file)
+
+    # The edited alias already exists in the active tomb.
+    if edits["alias"] != alias and tomb_handler.is_existing_command(
+            ctx, edits["alias"]):
+        update = click.prompt(
+            constants.CMD_EDIT_OVERWRITE_PROMPT.format(alias))
+
+        if update.lower() != "y":
+            # Abort the action.
+            formatter.exit(constants.WARN_ACTION_ABORTED)
+        else:
+            # We need to remove the old command if we're not overwriting it.
+            tomb_handler.remove_command(ctx, alias)
+    elif not tomb_handler.is_existing_command(ctx, edits["alias"]):
+        # Remember to remove the old command if we're adding a new one.
+        tomb_handler.remove_command(ctx, alias)
+
+    # Update the command.
+    tomb_handler.add_command(
+        ctx, edits["command"], edits["alias"], edits["description"])
+    formatter.print_success(constants.CMD_EDIT_OK)
+
+
+def read_edits(f):
+    """Read the edits from the provided file.
+
+    Arguments:
+        f (file): The file, containing user edits.
+
+    Returns:
+        A `dict` containing the new alias, command and description.
+    """
+    d = dict()
+
+    for line in f:
+        if "=" in line:
+            # Strip out the edited alias, command and description from the
+            # file.
+            entry = [ln.strip() for ln in line.split("=", 1)]
+            d[entry[0].lower()] = entry[1]
+
+    # Check if the edits are valid, if not, cancel execution and print the
+    # proper error message.
+    err_message = validate_edits(d)
+    if err_message:
+        formatter.exit(err_message)
+
+    return d
+
+
+def validate_edits(edits):
+    """Check if the edits are valid.
+
+    Arguments:
+        edits (dict): Contains the edits to validate.
+
+    Returns:
+        A `str` describing the error, None if there are no errors.
+    """
+    # There should be an entry for the alias, command and description.
+    num_entries = len(edits)
+    if num_entries != 3:
+        return constants.CMD_EDIT_MISSING_KEYS.format(num_entries)
+
+    # Ensure that each key is present.
+    if "alias" not in edits:
+        return constants.CMD_EDIT_MISSING_KEY.format("alias")
+    if "command" not in edits:
+        return constants.CMD_EDIT_MISSING_KEY.format("command")
+    if "description" not in edits:
+        return constants.CMD_EDIT_MISSING_KEY.format("description")
+
+    # Ensure that each key has a value.
+    if not len(edits["alias"]):
+        return constants.CMD_EDIT_MISSING_VAL.format("alias")
+    if not len(edits["command"]):
+        return constants.CMD_EDIT_MISSING_VAL.format("command")
+    if not len(edits["description"]):
+        return constants.CMD_EDIT_MISSING_VAL.format("description")
+
+    return None

--- a/catacomb/commands/tomb/edit.py
+++ b/catacomb/commands/tomb/edit.py
@@ -4,7 +4,7 @@ import click
 
 from catacomb import settings
 from catacomb.common import constants
-from catacomb.utils import formatter, tomb_handler
+from catacomb.utils import formatter, helpers, tomb_handler
 
 from subprocess import call
 
@@ -24,7 +24,7 @@ def edit(ctx, alias):
         alias (str): The alias of the command to edit.
     """
     if not tomb_handler.is_existing_command(ctx, alias):
-        formatter.exit(constants.WARN_CMD_NOT_FOUND.format(alias))
+        helpers.exit(constants.WARN_CMD_NOT_FOUND.format(alias))
 
     editor = os.environ.get("EDITOR", settings.DEFAULT_EDITOR)
     cmd_info = tomb_handler.get_command(ctx, alias, True)
@@ -52,7 +52,7 @@ def edit(ctx, alias):
 
         if update.lower() != "y":
             # Abort the action.
-            formatter.exit(constants.WARN_ACTION_ABORTED)
+            helpers.exit(constants.WARN_ACTION_ABORTED)
         else:
             # We need to remove the old command if we're not overwriting it.
             tomb_handler.remove_command(ctx, alias)
@@ -88,7 +88,7 @@ def read_edits(f):
     # proper error message.
     err_message = validate_edits(d)
     if err_message:
-        formatter.exit(err_message)
+        helpers.exit(err_message)
 
     return d
 

--- a/catacomb/commands/tomb/use.py
+++ b/catacomb/commands/tomb/use.py
@@ -2,7 +2,7 @@ import click
 import os
 
 from catacomb.common import constants, errors
-from catacomb.utils import formatter, tomb_handler
+from catacomb.utils import formatter, helpers, tomb_handler
 
 
 @click.command(
@@ -51,14 +51,14 @@ def format_cmd(alias, cmd, params):
         return cmd.format(*params)
     except IndexError:
         # Not all the placeholders are provided with a value.
-        formatter.exit(constants.WARN_FMT_NUM_PARAMS.format(
+        helpers.exit(constants.WARN_FMT_NUM_PARAMS.format(
             alias, len(params)))
     except KeyError:
         # Placeholders aren't following the correct syntax.
-        formatter.exit(constants.WARN_FMT_PLACEHOLDER_SYNTAX)
+        helpers.exit(constants.WARN_FMT_PLACEHOLDER_SYNTAX)
     except ValueError:
         # Inconsistent use of placeholders in a command.
-        formatter.exit(constants.WARN_FMT_PLACEHOLDER_SYNTAX2)
+        helpers.exit(constants.WARN_FMT_PLACEHOLDER_SYNTAX2)
     except Exception:
         # This shouldn't be reachable, but just in case, we'll report it.
-        formatter.exit(errors.INVALID_FORMAT_USE_CMD.format(cmd))
+        helpers.exit(errors.INVALID_FORMAT_USE_CMD.format(cmd))

--- a/catacomb/common/about.py
+++ b/catacomb/common/about.py
@@ -1,4 +1,4 @@
 # Application information.
 name = "catacomb"
-version = "0.4.0"
+version = "0.5.0"
 description = "A minimalistic CLI tool for storing shell commands."

--- a/catacomb/common/constants.py
+++ b/catacomb/common/constants.py
@@ -58,6 +58,28 @@ CMD_CLEAN_PROMPT = (
     "You're about to completely destroy the contents of this "
     "tomb. Would you like to continue? (Y/n)")
 
+CMD_EDIT_NAME = "edit"
+CMD_EDIT_DESC = "Opens an editor to alter a command that's in the tomb."
+CMD_EDIT_OK = "The command was successfully updated."
+CMD_EDIT_OVERWRITE_PROMPT = (
+    "The alias '{0}' is already being used in this tomb. Would "
+    "you like to overwrite it? (Y/n)")
+CMD_EDIT_INIT_MSG = (
+    "# You are currently editing '{0}'. Only edit text on the right hand\n"
+    "# side of the equals sign, and keep entries on the same line.\n\n"
+    "ALIAS = {0}\n\n"
+    "COMMAND = {1}\n\n"
+    "DESCRIPTION = {2}\n\n"
+    "# End of file.\n")
+CMD_EDIT_MISSING_KEY = (
+    "The entry for '{0}' seems to have been corrupted. Don't remove any lines "
+    "and only edit text on the right hand side of the equals sign. Please try "
+    "again.")
+CMD_EDIT_MISSING_KEYS = (
+    "Oops, we found an unexpected number of entries. 3 expected, {0} were "
+    "found. Please try again.")
+CMD_EDIT_MISSING_VAL = ("A value for '{0}' was not entered, please try again.")
+
 CMD_STATUS_NAME = "status"
 CMD_STATUS_DESC = "Shows the current tombs status."
 CMD_STATUS_OK = (
@@ -76,7 +98,7 @@ CMD_RM_OK = "Successfully removed the command with alias '{0}' from the tomb."
 # General command related warnings.
 WARN_ACTION_ABORTED = "The action was aborted."
 WARN_CMD_NOT_FOUND = (
-    "The alias '{0}' doesn't correspond to any of the contents in this tomb.")
+    "The alias '{0}' doesn't correspond to any of the commands in this tomb.")
 WARN_EMPTY_CATACOMB = "Nothing but empty rooms and dirt..."
 WARN_EMPTY_TOMB = "Nothing but crumbled bones and dust..."
 WARN_TOMB_EXISTS = "The tomb with alias '{0}' already exists."

--- a/catacomb/settings.py
+++ b/catacomb/settings.py
@@ -10,6 +10,8 @@ DEFAULT_CONFIG = {
     "open_tomb_name": TOMB_DEFAULT_FILE_NAME
 }
 
+DEFAULT_EDITOR = "vim"
+
 DEFAULT_TOMB_CONTENTS = {
     "commands": {},
     "description": "-"

--- a/catacomb/utils/catacomb_handler.py
+++ b/catacomb/utils/catacomb_handler.py
@@ -3,7 +3,7 @@ import os
 
 from catacomb import settings
 from catacomb.common import constants, errors
-from catacomb.utils import file_handler, formatter
+from catacomb.utils import file_handler, formatter, helpers
 
 
 def is_existing_tomb(ctx, tomb_name):
@@ -82,7 +82,7 @@ def open_tomb(ctx, tomb_name):
     if is_existing_tomb(ctx, tomb_name):
         ctx.obj.set_open_tomb(tomb_name)
     else:
-        formatter.exit(errors.TOMB_OPEN_UNKNOWN.format(tomb_name))
+        helpers.exit(errors.TOMB_OPEN_UNKNOWN.format(tomb_name))
 
 
 def remove_tomb(ctx, tomb_name):
@@ -94,4 +94,4 @@ def remove_tomb(ctx, tomb_name):
     if is_existing_tomb(ctx, tomb_name):
         os.remove(os.path.join(ctx.obj.catacomb_dir, tomb_name))
     else:
-        formatter.exit(errors.TOMB_BURY_UNKNOWN.format(tomb_name))
+        helpers.exit(errors.TOMB_BURY_UNKNOWN.format(tomb_name))

--- a/catacomb/utils/file_handler.py
+++ b/catacomb/utils/file_handler.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from catacomb.common import constants, errors
-from catacomb.utils import formatter
+from catacomb.utils import helpers
 
 
 def create(path, contents=None):
@@ -12,7 +12,7 @@ def create(path, contents=None):
         contents (str): The file contents.
     """
     if os.path.exists(path):
-        formatter.exit(errors.FILE_CREATE_OVERWRITE.format(path))
+        helpers.exit(errors.FILE_CREATE_OVERWRITE.format(path))
 
     if not contents:
         # Allow the creation of an empty file.
@@ -29,7 +29,7 @@ def update(path, contents):
         contents (str): The file contents.
     """
     if not os.path.exists(path):
-        formatter.exit(errors.FILE_UPDATE_UNKNOWN.format(path))
+        helpers.exit(errors.FILE_UPDATE_UNKNOWN.format(path))
 
     with open(path, "w") as f:
         f.write(json.dumps(contents, indent=constants.INDENT_NUM_SPACES))
@@ -45,7 +45,7 @@ def read(path):
         A `dict`, representing the contents of the file, if the file exists.
     """
     if not os.path.exists(path):
-        formatter.exit(errors.FILE_READ_UNKNOWN.format(path))
+        helpers.exit(errors.FILE_READ_UNKNOWN.format(path))
 
     with open(path, "r") as f:
         contents = json.load(f)

--- a/catacomb/utils/formatter.py
+++ b/catacomb/utils/formatter.py
@@ -64,6 +64,15 @@ def exit(message):
     sys.exit(1)
 
 
+def print_error(message):
+    """Correctly styles and prints an error message to standard output.
+
+    Arguments:
+        message (str): An error message.
+    """
+    click.echo(color_text(message, "red"), err=True)
+
+
 def print_warning(message):
     """Correctly styles and prints a warning message to standard output.
 

--- a/catacomb/utils/helpers.py
+++ b/catacomb/utils/helpers.py
@@ -1,0 +1,13 @@
+import sys
+
+from catacomb.utils import formatter
+
+
+def exit(message):
+    """Prints an error and forces execution of the application to stop.
+
+    Arguments:
+        message (str): An error message.
+    """
+    formatter.print_error(message)
+    sys.exit(1)

--- a/catacomb/utils/tomb_handler.py
+++ b/catacomb/utils/tomb_handler.py
@@ -35,6 +35,17 @@ def clean_tomb(ctx):
     update_tomb_commands(ctx, {})
 
 
+def is_existing_command(ctx, alias):
+    """Checks if a command belonging to the given alias exists in the active
+    tomb.
+
+    Arguments:
+        alias (str): The command alias.
+    """
+    data = read_tomb_commands(ctx)
+    return alias in data
+
+
 def add_command(ctx, command, alias, description):
     """Adds a new command to the current tomb.
 
@@ -53,18 +64,22 @@ def add_command(ctx, command, alias, description):
     update_tomb_commands(ctx, data)
 
 
-def get_command(ctx, alias):
+def get_command(ctx, alias, desc=False):
     """Retrieves a command from the current tomb, using its alias.
 
     Arguments:
         alias (str): The alias to save the command as.
+        desc (bool): If True, return the description as well (default: False).
 
     Returns:
-        The command as a `string`, or None if not found.
+        The command as a `string`, or a `tuple` containing the command and
+        description if desc is True, or None if not found.
     """
     data = read_tomb_commands(ctx)
 
     if alias in data:
+        if desc:
+            return (data[alias]["command"], data[alias]["description"])
         return data[alias]["command"]
 
     return None

--- a/catacomb/utils/tomb_handler.py
+++ b/catacomb/utils/tomb_handler.py
@@ -41,6 +41,9 @@ def is_existing_command(ctx, alias):
 
     Arguments:
         alias (str): The command alias.
+
+    Returns:
+        A `bool`.
     """
     data = read_tomb_commands(ctx)
     return alias in data

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
 
     # Metadata
     author = "Mitchell Jeitani",
-    author_email = "mitchelljeitani@hotmail.com",
+    author_email = "mitchelljeitani@gmail.com",
     description = about.description,
     license = "MIT",
     keywords = "command-line shell productivity storage",


### PR DESCRIPTION
* Loads the users' default text editor or `vim` to edit a command.
* Done through the `tomb edit` command.
* Refactored some code to do with exiting the application.
* Updated some prompts.
* Added a new helper function `is_existing_command`.