### PR TITLE
Closes #21: Improvements to edit command cross-platform.

### DIFF
--- a/catacomb/common/about.py
+++ b/catacomb/common/about.py
@@ -1,4 +1,4 @@
 # Application information.
 name = "catacomb"
-version = "0.5.0"
+version = "0.5.1"
 description = "A minimalistic CLI tool for storing shell commands."

--- a/catacomb/settings.py
+++ b/catacomb/settings.py
@@ -10,7 +10,9 @@ DEFAULT_CONFIG = {
     "open_tomb_name": TOMB_DEFAULT_FILE_NAME
 }
 
-DEFAULT_EDITOR = "vim"
+DEFAULT_EDITOR_UNIX = "vi"
+DEFAULT_EDITOR_WIN32 = "edit"
+DEFAULT_EDITOR_WIN64 = "notepad"
 
 DEFAULT_TOMB_CONTENTS = {
     "commands": {},

--- a/catacomb/utils/helpers.py
+++ b/catacomb/utils/helpers.py
@@ -1,6 +1,58 @@
+import os
+import platform
 import sys
+import uuid
 
+from catacomb import settings
 from catacomb.utils import formatter
+
+from collections import defaultdict
+
+
+def get_platform():
+    """Gets the users operating system.
+
+    Returns:
+        An `int` representing the users operating system.
+            0: Windows x86 (32 bit)
+            1: Windows x64 (64 bit)
+            2: Mac OS
+            3: Linux
+        If the operating system is unknown, -1 will be returned.
+    """
+    return defaultdict(lambda: -1, {
+        "Windows": 1 if platform.machine().endswith("64") else 0,
+        "Darwin": 2,
+        "Linux:": 3,
+    })[platform.system()]
+
+
+def default_editor():
+    """Retrieves the platforms respective 'default' editor.
+
+    Returns:
+        A `str` representing the editor.
+    """
+    return defaultdict(lambda: settings.DEFAULT_EDITOR_UNIX, {
+        0: settings.DEFAULT_EDITOR_WIN32,
+        1: settings.DEFAULT_EDITOR_WIN64,
+    })[get_platform()]
+
+
+def random_fname():
+    """Generates a random file name. In the *very* unlikely case that `uuid4`
+    generates a file name that already exists, we'll generate a new one until
+    a unique file name is generated.
+
+    Returns:
+        A unique file name `str`.
+    """
+    fname = "{}.tmp".format(str(uuid.uuid4()))
+
+    while (os.path.isfile(fname)):
+        fname = "{}.tmp".format(str(uuid.uuid4()))
+
+    return fname
 
 
 def exit(message):


### PR DESCRIPTION
The `tomb edit` command was only working on platforms with the text editor `vim` installed. With this change, we use editors that are available by default on all major platforms.

* `vi` for Mac and UNIX
* `notepad` for win64
* `edit` for win32